### PR TITLE
implement login/logout with Context API

### DIFF
--- a/src/MemoApp.jsx
+++ b/src/MemoApp.jsx
@@ -52,11 +52,7 @@ function MemoApp() {
     <div className="memo-app">
       <Header />
       <div className="memo-app-container">
-        <Sidebar
-          memos={memos}
-          onEdit={handleEdit}
-          onAdd={handleAdd}
-        />
+        <Sidebar memos={memos} onEdit={handleEdit} onAdd={handleAdd} />
         <Contents
           editing={memoInput.editing}
           text={memoInput.content}

--- a/src/components/AuthProvider.jsx
+++ b/src/components/AuthProvider.jsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useState } from "react";
 
-export const AuthContext = React.createContext(false);
+const AuthContext = React.createContext(false);
 
-const AuthProvider = ({ children }) => {
+export const AuthProvider = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   // Stub method for login feature
@@ -27,4 +27,4 @@ const AuthProvider = ({ children }) => {
   );
 };
 
-export default AuthProvider;
+export const useAuth = () => useContext(AuthContext);

--- a/src/components/AuthProvider.jsx
+++ b/src/components/AuthProvider.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useState } from "react";
+
+export const AuthContext = React.createContext(false);
+
+const AuthProvider = ({ children }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  // Stub method for login feature
+  const login = () => {
+    setIsLoggedIn(true);
+  };
+
+  // Stub method for logout feature
+  const logout = () => {
+    setIsLoggedIn(false);
+  };
+
+  const context = {
+    isLoggedIn,
+    login,
+    logout,
+  };
+
+  return (
+    <AuthContext.Provider value={context}>{children}</AuthContext.Provider>
+  );
+};
+
+export default AuthProvider;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,14 @@
+import { useAuth } from "../hooks/useAuth";
+import LoginButton from "./LoginButton";
+import LogoutButton from "./LogoutButton";
+
 export default function Header() {
+  const { isLoggedIn } = useAuth();
+
   return (
     <header className="memo-app-header">
       <p>Super Simple Memo App</p>
+      {isLoggedIn ? <LogoutButton /> : <LoginButton />}
     </header>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from "../hooks/useAuth";
+import { useAuth } from "./AuthProvider";
 import LoginButton from "./LoginButton";
 import LogoutButton from "./LogoutButton";
 

--- a/src/components/LoginButton.jsx
+++ b/src/components/LoginButton.jsx
@@ -1,0 +1,16 @@
+import { useAuth } from "../hooks/useAuth";
+
+export default function LoginButton() {
+  const { login } = useAuth();
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    login();
+  };
+
+  return (
+    <button className="memo-app-login-button" onClick={handleClick}>
+      Login
+    </button>
+  );
+}

--- a/src/components/LoginButton.jsx
+++ b/src/components/LoginButton.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from "../hooks/useAuth";
+import { useAuth } from "./AuthProvider";
 
 export default function LoginButton() {
   const { login } = useAuth();

--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -1,0 +1,16 @@
+import { useAuth } from "../hooks/useAuth";
+
+export default function LogoutButton() {
+  const { logout } = useAuth();
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    logout();
+  };
+
+  return (
+    <button className="memo-app-logout-button" onClick={handleClick}>
+      Logout
+    </button>
+  );
+}

--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from "../hooks/useAuth";
+import { useAuth } from "./AuthProvider";
 
 export default function LogoutButton() {
   const { logout } = useAuth();

--- a/src/components/MemoDetail.jsx
+++ b/src/components/MemoDetail.jsx
@@ -1,4 +1,8 @@
+import { useAuth } from "../hooks/useAuth";
+
 export default function MemoDetail(props) {
+  const { isLoggedIn } = useAuth();
+
   return (
     <form onSubmit={props.onSave} className="memo-app-form">
       <textarea
@@ -7,12 +11,14 @@ export default function MemoDetail(props) {
         value={props.text}
         className="memo-app-form-text-area"
       />
-      <div className="memo-app-button-area">
-        <button className="memo-app-save-button">Save</button>
-        <button className="memo-app-delete-button" onClick={props.onDelete}>
-          Delete
-        </button>
-      </div>
+      {isLoggedIn && (
+        <div className="memo-app-button-area">
+          <button className="memo-app-save-button">Save</button>
+          <button className="memo-app-delete-button" onClick={props.onDelete}>
+            Delete
+          </button>
+        </div>
+      )}
     </form>
   );
 }

--- a/src/components/MemoDetail.jsx
+++ b/src/components/MemoDetail.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from "../hooks/useAuth";
+import { useAuth } from "./AuthProvider";
 
 export default function MemoDetail(props) {
   const { isLoggedIn } = useAuth();

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,11 +1,14 @@
+import { useAuth } from "../hooks/useAuth";
 import AddButton from "./AddButton";
 import MemoList from "./MemoList";
 
 export default function Sidebar(props) {
+  const { isLoggedIn } = useAuth();
+
   return (
     <aside className="memo-app-sidebar">
       <MemoList memos={props.memos} onEdit={props.onEdit} />
-      <AddButton onClick={props.onAdd} />
+      {isLoggedIn && <AddButton onClick={props.onAdd} />}
     </aside>
   );
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
-import { useAuth } from "../hooks/useAuth";
 import AddButton from "./AddButton";
+import { useAuth } from "./AuthProvider";
 import MemoList from "./MemoList";
 
 export default function Sidebar(props) {

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+import { AuthContext } from "../components/AuthProvider";
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  return context;
+};

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,7 +1,0 @@
-import { useContext } from "react";
-import { AuthContext } from "../components/AuthProvider";
-
-export const useAuth = () => {
-  const context = useContext(AuthContext);
-  return context;
-};

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,10 @@ ul {
 
 .memo-app-header {
   margin-left: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 400px;
 }
 
 .memo-app-container {
@@ -60,4 +64,14 @@ ul {
 .memo-app-save-button {
   width: 100%;
   margin-right: 8px;
+}
+
+.memo-app-login-button {
+  height: 24px;
+  width: 56px;
+}
+
+.memo-app-logout-button {
+  height: 24px;
+  width: 56px;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import AuthProvider from "./components/AuthProvider";
+import { AuthProvider } from "./components/AuthProvider";
 import "./index.css";
 import MemoApp from "./MemoApp";
 import reportWebVitals from "./reportWebVitals";

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import AuthProvider from "./components/AuthProvider";
 import "./index.css";
 import MemoApp from "./MemoApp";
 import reportWebVitals from "./reportWebVitals";
@@ -7,7 +8,9 @@ import reportWebVitals from "./reportWebVitals";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <MemoApp />
+    <AuthProvider>
+      <MemoApp />
+    </AuthProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
Contextプラクティス用、ログインボタンつきメモアプリSPA版です。

Provider Pattern的な感じで、`AuthProvider` コンポーネントがContextを使った機能を提供するようにしています。
ログイン/ログアウト機能は`useAuth`フックを呼び出すだけで利用でき、利用するコンポーネントからはContextを使っているかどうかといった詳細は知る必要がないようにしてあります。

基本的には下記の記事を参考にして実装しました。

- [React Context を export するのはアンチパターンではないかと考える
](https://blog.stin.ink/articles/do-not-export-react-context)
- [カスタムフックで Context をエクスポートしないようリファクタリングする](https://react.keicode.com/basics/context-custom-hook.php)

HooksのPRをOpenにしてある関係上、`hooks`ブランチに対してPRを作成しています。

ESLint, Prettierの設定は[js-practices](https://github.com/fjordllc/js-practices)を参考にしています。

![730b3474488224bf56e493b0c6641ac9](https://user-images.githubusercontent.com/12785301/209853434-e8158dc5-4621-4d0e-ae02-5980e550c369.gif)
